### PR TITLE
Allow for dual config

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,8 @@ docker create \
   -e PGID=1000 \
   -e QUASSEL_CORE=192.168.1.10 \
   -e QUASSEL_PORT=4242 \
-  -e HTTPS=false \
-  -e FORCE_DEFAULT=true \
   -e URL_BASE=/quassel `#optional` \
   -p 64080:64080 \
-  -p 64443:64443 \
   -v <path to data>:/config \
   --restart unless-stopped \
   linuxserver/quassel-web
@@ -82,14 +79,11 @@ services:
       - PGID=1000
       - QUASSEL_CORE=192.168.1.10
       - QUASSEL_PORT=4242
-      - HTTPS=false
-      - FORCE_DEFAULT=true
       - URL_BASE=/quassel #optional
     volumes:
       - <path to data>:/config
     ports:
       - 64080:64080
-      - 64443:64443
     restart: unless-stopped
 ```
 
@@ -100,13 +94,10 @@ Container images are configured using parameters passed at runtime (such as thos
 | Parameter | Function |
 | :----: | --- |
 | `-p 64080` | will map the container's port 64080 to port 64080 on the host |
-| `-p 64443` | will map the container's port 64443 to port 64443 on the host |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e QUASSEL_CORE=192.168.1.10` | specify the URL or IP address of your Quassel Core instance |
 | `-e QUASSEL_PORT=4242` | specify the port of your Quassel Core instance |
-| `-e HTTPS=false` | specify `true` to use https on `64443` or false to use http on `64080` |
-| `-e FORCE_DEFAULT=true` | specify `true` to use only the default instance of Quassel Core specified above |
 | `-e URL_BASE=/quassel` | Specify a url-base in reverse proxy setups ie. `/quassel` |
 | `-v /config` | this will store config on the docker host |
 
@@ -127,7 +118,7 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the envrionment variables we recommend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
+By default this container webui will be available on `http://$SERVER_IP:64080`. To setup this container you can either use the envrionment variables we recommend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
 The configuration file using this method can be found at:
 ```
 /config/settings-user.js

--- a/README.md
+++ b/README.md
@@ -55,10 +55,9 @@ docker create \
   -e PGID=1000 \
   -e QUASSEL_CORE=192.168.1.10 \
   -e QUASSEL_PORT=4242 \
-  -e URL_BASE=/quassel \
-  -e HTTPS=true \
-  -e FORCE_DEFAULT=false \
-  -e ADVANCED=false \
+  -e HTTPS=false \
+  -e FORCE_DEFAULT=true \
+  -e URL_BASE=/quassel `#optional` \
   -p 64080:64080 \
   -p 64443:64443 \
   -v <path to data>:/config \
@@ -83,10 +82,9 @@ services:
       - PGID=1000
       - QUASSEL_CORE=192.168.1.10
       - QUASSEL_PORT=4242
-      - URL_BASE=/quassel
-      - HTTPS=true
-      - FORCE_DEFAULT=false
-      - ADVANCED=false
+      - HTTPS=false
+      - FORCE_DEFAULT=true
+      - URL_BASE=/quassel #optional
     volumes:
       - <path to data>:/config
     ports:
@@ -107,10 +105,9 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e QUASSEL_CORE=192.168.1.10` | specify the URL or IP address of your Quassel Core instance |
 | `-e QUASSEL_PORT=4242` | specify the port of your Quassel Core instance |
+| `-e HTTPS=false` | specify `true` to use https on `64443` or false to use http on `64080` |
+| `-e FORCE_DEFAULT=true` | specify `true` to use only the default instance of Quassel Core specified above |
 | `-e URL_BASE=/quassel` | Specify a url-base in reverse proxy setups ie. `/quassel` |
-| `-e HTTPS=true` | specify `true` to use https on `64443` or false to use http on `64080` |
-| `-e FORCE_DEFAULT=false` | specify `true` to use only the default instance of Quassel Core specified above |
-| `-e ADVANCED=false` | specify `true` to configure through `/config/settings-user.js` ignoring the above environmental variables |
 | `-v /config` | this will store config on the docker host |
 
 ## User / Group Identifiers
@@ -130,7 +127,11 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the first five environmental variables as specified above or set the environmental variable `ADVANCED` to `true` and edit `/config/settings-user.js` to configure your instance, ignoring the other environmental variables, this will allow more granular control of your quassel web instance.
+By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the envrionment variables we reccomend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
+The configuration file using this method can be found at:
+```
+/config/settings-user.js
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the envrionment variables we reccomend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
+By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the envrionment variables we recommend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
 The configuration file using this method can be found at:
 ```
 /config/settings-user.js

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ docker create \
   -e URL_BASE=/quassel \
   -e HTTPS=true \
   -e FORCE_DEFAULT=false \
+  -e ADVANCED=false \
   -p 64080:64080 \
   -p 64443:64443 \
   -v <path to data>:/config \
@@ -85,6 +86,7 @@ services:
       - URL_BASE=/quassel
       - HTTPS=true
       - FORCE_DEFAULT=false
+      - ADVANCED=false
     volumes:
       - <path to data>:/config
     ports:
@@ -108,6 +110,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e URL_BASE=/quassel` | Specify a url-base in reverse proxy setups ie. `/quassel` |
 | `-e HTTPS=true` | specify `true` to use https on `64443` or false to use http on `64080` |
 | `-e FORCE_DEFAULT=false` | specify `true` to use only the default instance of Quassel Core specified above |
+| `-e ADVANCED=false` | specify `true` to configure through `/config/settings-user.js` ignoring the above environmental variables |
 | `-v /config` | this will store config on the docker host |
 
 ## User / Group Identifiers
@@ -127,7 +130,7 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-By default this container webui will be available on `https://$SERVER_IP:64443`.  To setup this container you can either use the environmental variables as specified above and these will overwrite the respective settings in `/config/settings-user.js` or omit the environmental variables and edit `/config/settings-user.js` directly.
+By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the first five environmental variables as specified above or set the environmental variable `ADVANCED` to `true` and edit `/config/settings-user.js` to configure your instance, ignoring the other environmental variables, this will allow more granular control of your quassel web instance.
 
 
 
@@ -154,15 +157,6 @@ Below are the instructions for updating containers:
 * Start the new container: `docker start quassel-web`
 * You can also remove the old dangling images: `docker image prune`
 
-### Via Taisun auto-updater (especially useful if you don't remember the original parameters)
-* Pull the latest image at its tag and replace it with the same env variables in one shot:
-  ```
-  docker run --rm \
-  -v /var/run/docker.sock:/var/run/docker.sock taisun/updater \
-  --oneshot quassel-web
-  ```
-* You can also remove the old dangling images: `docker image prune`
-
 ### Via Docker Compose
 * Update all images: `docker-compose pull`
   * or update a single image: `docker-compose pull quassel-web`
@@ -170,6 +164,36 @@ Below are the instructions for updating containers:
   * or update a single container: `docker-compose up -d quassel-web`
 * You can also remove the old dangling images: `docker image prune`
 
+### Via Watchtower auto-updater (especially useful if you don't remember the original parameters)
+* Pull the latest image at its tag and replace it with the same env variables in one run:
+  ```
+  docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  containrrr/watchtower \
+  --run-once quassel-web
+  ```
+* You can also remove the old dangling images: `docker image prune`
+
+## Building locally
+
+If you want to make local modifications to these images for development purposes or just to customize the logic: 
+```
+git clone https://github.com/linuxserver/docker-quassel-web.git
+cd docker-quassel-web
+docker build \
+  --no-cache \
+  --pull \
+  -t linuxserver/quassel-web:latest .
+```
+
+The ARM variants can be built on x86_64 hardware using `multiarch/qemu-user-static`
+```
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
+```
+
+Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64`.
+
 ## Versions
 
+* **18.05.19:** - Reconfigure environmental variable setup.
 * **28.04.19:** - Initial Release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -23,20 +23,27 @@ param_usage_include_env: true
 param_env_vars:
   - { env_var: "QUASSEL_CORE", env_value: "192.168.1.10", desc: "specify the URL or IP address of your Quassel Core instance" }
   - { env_var: "QUASSEL_PORT", env_value: "4242", desc: "specify the port of your Quassel Core instance" }
-  - { env_var: "URL_BASE", env_value: "/quassel", desc: "Specify a url-base in reverse proxy setups ie. `/quassel`" }
-  - { env_var: "HTTPS", env_value: "true", desc: "specify `true` to use https on `64443` or false to use http on `64080`" }
-  - { env_var: "FORCE_DEFAULT", env_value: "false", desc: "specify `true` to use only the default instance of Quassel Core specified above" } 
-  - { env_var: "ADVANCED", env_value: "false", desc: "specify `true` to configure through `/config/settings-user.js` ignoring the above environmental variables" }  
+  - { env_var: "HTTPS", env_value: "false", desc: "specify `true` to use https on `64443` or false to use http on `64080`" }
+  - { env_var: "FORCE_DEFAULT", env_value: "true", desc: "specify `true` to use only the default instance of Quassel Core specified above" } 
 
 param_usage_include_ports: true
 param_ports:
   - { external_port: "64080", internal_port: "64080", port_desc: "will map the container's port 64080 to port 64080 on the host" }
   - { external_port: "64443", internal_port: "64443", port_desc: "will map the container's port 64443 to port 64443 on the host" }
 
+# optional container parameters
+opt_param_usage_include_env: true
+opt_param_env_vars:
+  - { env_var: "URL_BASE", env_value: "/quassel", desc: "Specify a url-base in reverse proxy setups ie. `/quassel`" }
+
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the first five environmental variables as specified above or set the environmental variable `ADVANCED` to `true` and edit `/config/settings-user.js` to configure your instance, ignoring the other environmental variables, this will allow more granular control of your quassel web instance.
+  By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the envrionment variables we reccomend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
+  The configuration file using this method can be found at:
+  ```
+  /config/settings-user.js
+  ```
 # changelog
 changelogs:
 - { date: "18.05.19:", desc: "Reconfigure environmental variable setup." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,7 +39,7 @@ opt_param_env_vars:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the envrionment variables we reccomend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
+  By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the envrionment variables we recommend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
   The configuration file using this method can be found at:
   ```
   /config/settings-user.js

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -25,7 +25,8 @@ param_env_vars:
   - { env_var: "QUASSEL_PORT", env_value: "4242", desc: "specify the port of your Quassel Core instance" }
   - { env_var: "URL_BASE", env_value: "/quassel", desc: "Specify a url-base in reverse proxy setups ie. `/quassel`" }
   - { env_var: "HTTPS", env_value: "true", desc: "specify `true` to use https on `64443` or false to use http on `64080`" }
-  - { env_var: "FORCE_DEFAULT", env_value: "false", desc: "specify `true` to use only the default instance of Quassel Core specified above" }  
+  - { env_var: "FORCE_DEFAULT", env_value: "false", desc: "specify `true` to use only the default instance of Quassel Core specified above" } 
+  - { env_var: "ADVANCED", env_value: "false", desc: "specify `true` to configure through `/config/settings-user.js` ignoring the above environmental variables" }  
 
 param_usage_include_ports: true
 param_ports:
@@ -35,7 +36,8 @@ param_ports:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  By default this container webui will be available on `https://$SERVER_IP:64443`.  To setup this container you can either use the environmental variables as specified above and these will overwrite the respective settings in `/config/settings-user.js` or omit the environmental variables and edit `/config/settings-user.js` directly.
+  By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the first five environmental variables as specified above or set the environmental variable `ADVANCED` to `true` and edit `/config/settings-user.js` to configure your instance, ignoring the other environmental variables, this will allow more granular control of your quassel web instance.
 # changelog
 changelogs:
+- { date: "18.05.19:", desc: "Reconfigure environmental variable setup." }
 - { date: "28.04.19:", desc: "Initial Release." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -23,13 +23,10 @@ param_usage_include_env: true
 param_env_vars:
   - { env_var: "QUASSEL_CORE", env_value: "192.168.1.10", desc: "specify the URL or IP address of your Quassel Core instance" }
   - { env_var: "QUASSEL_PORT", env_value: "4242", desc: "specify the port of your Quassel Core instance" }
-  - { env_var: "HTTPS", env_value: "false", desc: "specify `true` to use https on `64443` or false to use http on `64080`" }
-  - { env_var: "FORCE_DEFAULT", env_value: "true", desc: "specify `true` to use only the default instance of Quassel Core specified above" } 
 
 param_usage_include_ports: true
 param_ports:
   - { external_port: "64080", internal_port: "64080", port_desc: "will map the container's port 64080 to port 64080 on the host" }
-  - { external_port: "64443", internal_port: "64443", port_desc: "will map the container's port 64443 to port 64443 on the host" }
 
 # optional container parameters
 opt_param_usage_include_env: true
@@ -39,7 +36,7 @@ opt_param_env_vars:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  By default this container webui will be available on `http://$SERVER_IP:64080` if `HTTPS` is set to `false` or `https://$SERVER_IP:64443` if `HTTPS` is set to `true`.  To setup this container you can either use the envrionment variables we recommend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
+  By default this container webui will be available on `http://$SERVER_IP:64080`. To setup this container you can either use the envrionment variables we recommend or manually setup the configuration file by leaving out the `QUASSEL_CORE` environment variable among others. 
   The configuration file using this method can be found at:
   ```
   /config/settings-user.js

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,5 +1,13 @@
 #!/usr/bin/with-contenv bash
 
+# permissions function
+chownfiles () {
+  echo "[cont-init.d] setting file permissions this may take some time ..."
+  chown -R abc:abc \
+    /app/quassel-web \
+    /config
+}
+
 # The user has defined QUASSEL_CORE use env settings
 if [ "${QUASSEL_CORE+x}" ]; then
   echo "[cont-init.d] QUASSEL_CORE set, injecting env variables into settings.js"
@@ -14,6 +22,7 @@ if [ "${QUASSEL_CORE+x}" ]; then
       echo "[cont-init.d] ${i} is required to setup container with env variables falling back to config file"
       [[ ! -f /config/settings-user.js ]] && \
         cp -pr /app/quassel-web/settings.js /config/settings-user.js
+      chownfiles
       exit 0
     fi
   done
@@ -45,8 +54,4 @@ else
     cp -pr /app/quassel-web/settings.js /config/settings-user.js
 fi
 
-# permissions
-echo "[cont-init.d] setting file permissions this may take some time ..."
-chown -R abc:abc \
-  /app/quassel-web \
-  /config
+chownfiles

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -14,7 +14,6 @@ if [ "${QUASSEL_CORE+x}" ]; then
   # Env variable validation
   VARS=( \
   QUASSEL_PORT \
-  FORCE_DEFAULT \
   HTTPS
   )
   for i in "${VARS[@]}"; do

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,44 +1,48 @@
 #!/usr/bin/with-contenv bash
 
-# copy config files
+# copy settings-user.js if doesn't exist
 [[ ! -f /config/settings-user.js ]] ; \
 	cp -pr /defaults/settings.js /config/settings-user.js
+
+# Fresh settings-env.js if using env variable
+rm /app/quassel-web/settings-env.js && \
+    cp -pr /defaults/settings.js /app/quassel-web/settings-env.js
 
 # add possibility to use env variables
 [[ "${QUASSEL_CORE}" ]] && \
         sed -i "s#host:.*//#host: '${QUASSEL_CORE}', //#g" \
-            /config/settings-user.js
+            /app/quassel-web/settings-env.js
 
 [[ "${QUASSEL_PORT}" ]] && \
         sed -i "s#port:.*,// quasselcore#port: ${QUASSEL_PORT}, // quasselcore#g" \
-            /config/settings-user.js
+            /app/quassel-web/settings-env.js
 
 [[ "${URL_BASE}" ]] && \
         sed -i "s#prefixpath:.*//#prefixpath: \'${URL_BASE}\', //#g" \
-            /config/settings-user.js
+            /app/quassel-web/settings-env.js
 
 if [ "${FORCE_DEFAULT}" == "true" ];then
         sed -i "s#forcedefault:.*//#forcedefault: true, //#g" \
-            /config/settings-user.js
+            /app/quassel-web/settings-env.js
 fi
 
 if [ "${FORCE_DEFAULT}" == "false" ];then
         sed -i "s#forcedefault:.*//#forcedefault: false, //#g" \
-            /config/settings-user.js
+            /app/quassel-web/settings-env.js
 fi
 
 if [ "${HTTPS}" == "true" ];then
         sed -i "s#mode:.*//#mode: 'https', //#g" \
-            /config/settings-user.js && \
+            /app/quassel-web/settings-env.js && \
         sed -i "s#port:.*// Port on which to listen#port: 64443, // Port on which to listen#g" \
-            /config/settings-user.js
+            /app/quassel-web/settings-env.js
 fi
             
 if [ "${HTTPS}" == "false" ];then
         sed -i "s#mode:.*//#mode: 'http', //#g" \
-            /config/settings-user.js && \
+            /app/quassel-web/settings-env.js && \
         sed -i "s#port:.*// Port on which to listen#port: 64080, // Port on which to listen#g" \
-            /config/settings-user.js
+            /app/quassel-web/settings-env.js
 fi
 
 # permissions

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,11 +1,11 @@
 #!/usr/bin/with-contenv bash
 
 # copy settings-user.js if doesn't exist
-[[ ! -f /config/settings-user.js ]] ; \
+[[ ! -f /config/settings-user.js ]] && \
 	cp -pr /app/quassel-web/settings.js /config/settings-user.js
 
 # Fresh settings-env.js if using env variable
-[[ -f /app/quassel-web/settings-env.js ]] ; \
+[[ -f /app/quassel-web/settings-env.js ]] && \
     rm /app/quassel-web/settings-env.js
 
 # Copy settings to be used for env variables

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,54 +1,52 @@
 #!/usr/bin/with-contenv bash
 
-# copy settings-user.js if doesn't exist
-[[ ! -f /config/settings-user.js ]] && \
-	cp -pr /app/quassel-web/settings.js /config/settings-user.js
-
-# Fresh settings-env.js if using env variable
-[[ -f /app/quassel-web/settings-env.js ]] && \
-    rm /app/quassel-web/settings-env.js
-
-# Copy settings to be used for env variables
-cp -pr /app/quassel-web/settings.js /app/quassel-web/settings-env.js
-
-# add possibility to use env variables
-[[ "${QUASSEL_CORE}" ]] && \
-        sed -i "s#host:.*//#host: '${QUASSEL_CORE}', //#g" \
-            /app/quassel-web/settings-env.js
-
-[[ "${QUASSEL_PORT}" ]] && \
-        sed -i "s#port:.*,// quasselcore#port: ${QUASSEL_PORT}, // quasselcore#g" \
-            /app/quassel-web/settings-env.js
-
-[[ "${URL_BASE}" ]] && \
-        sed -i "s#prefixpath:.*//#prefixpath: \'${URL_BASE}\', //#g" \
-            /app/quassel-web/settings-env.js
-
-if [ "${FORCE_DEFAULT}" == "true" ];then
-        sed -i "s#forcedefault:.*//#forcedefault: true, //#g" \
-            /app/quassel-web/settings-env.js
-fi
-
-if [ "${FORCE_DEFAULT}" == "false" ];then
-        sed -i "s#forcedefault:.*//#forcedefault: false, //#g" \
-            /app/quassel-web/settings-env.js
-fi
-
-if [ "${HTTPS}" == "true" ];then
-        sed -i "s#mode:.*//#mode: 'https', //#g" \
-            /app/quassel-web/settings-env.js && \
-        sed -i "s#port:.*// Port on which to listen#port: 64443, // Port on which to listen#g" \
-            /app/quassel-web/settings-env.js
-fi
-            
-if [ "${HTTPS}" == "false" ];then
-        sed -i "s#mode:.*//#mode: 'http', //#g" \
-            /app/quassel-web/settings-env.js && \
-        sed -i "s#port:.*// Port on which to listen#port: 64080, // Port on which to listen#g" \
-            /app/quassel-web/settings-env.js
+# The user has defined QUASSEL_CORE use env settings
+if [ "${QUASSEL_CORE+x}" ]; then
+  echo "[cont-init.d] QUASSEL_CORE set, injecting env variables into settings.js"
+  # Env variable validation
+  VARS=( \
+  QUASSEL_PORT \
+  FORCE_DEFAULT \
+  HTTPS
+  )
+  for i in "${VARS[@]}"; do
+    if [ -z ${!i+x} ]; then
+      echo "[cont-init.d] ${i} is required to setup container with env variables falling back to config file"
+      [[ ! -f /config/settings-user.js ]] && \
+        cp -pr /app/quassel-web/settings.js /config/settings-user.js
+      exit 0
+    fi
+  done
+  cp -pr /app/quassel-web/settings.js /app/quassel-web/settings-env.js
+  # Env variable injection
+    sed -i \
+      -e "s#host:.*//#host: '${QUASSEL_CORE}', //#g" \
+      -e "s#port:.*,// quasselcore#port: ${QUASSEL_PORT}, // quasselcore#g" \
+      -e "s#forcedefault:.*//#forcedefault: true, //#g" \
+      /app/quassel-web/settings-env.js && \
+  [[ "${URL_BASE+x}" ]] && \
+    sed -i "s#prefixpath:.*//#prefixpath: \'${URL_BASE}\', //#g" \
+    /app/quassel-web/settings-env.js
+  if [ "${HTTPS}" == "true" ];then
+    sed -i \
+      -e "s#mode:.*//#mode: 'https', //#g" \
+      -e "s#port:.*// Port on which to listen#port: 64443, // Port on which to listen#g" \
+      /app/quassel-web/settings-env.js
+  else
+    sed -i \
+      -e "s#mode:.*//#mode: 'http', //#g" \
+      -e "s#port:.*// Port on which to listen#port: 64080, // Port on which to listen#g" \
+      /app/quassel-web/settings-env.js
+  fi
+# The user is not using env variables copy a default file if it does not exist
+else
+  [[ ! -f /config/settings-user.js ]] && \
+    echo "[cont-init.d] QUASSEL_CORE is not set, you will need to manually modify /config/settings-user.js"
+    cp -pr /app/quassel-web/settings.js /config/settings-user.js
 fi
 
 # permissions
+echo "[cont-init.d] setting file permissions this may take some time ..."
 chown -R abc:abc \
-	/app/quassel-web \
-	/config
+  /app/quassel-web \
+  /config

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -8,49 +8,33 @@ chownfiles () {
     /config
 }
 
-# The user has defined QUASSEL_CORE use env settings
-if [ "${QUASSEL_CORE+x}" ]; then
-  echo "[cont-init.d] QUASSEL_CORE set, injecting env variables into settings.js"
-  # Env variable validation
-  VARS=( \
-  QUASSEL_PORT \
-  HTTPS
-  )
-  for i in "${VARS[@]}"; do
-    if [ -z ${!i+x} ]; then
-      echo "[cont-init.d] ${i} is required to setup container with env variables falling back to config file"
-      [[ ! -f /config/settings-user.js ]] && \
-        cp -pr /app/quassel-web/settings.js /config/settings-user.js
-      chownfiles
-      exit 0
-    fi
-  done
-  cp -pr /app/quassel-web/settings.js /app/quassel-web/settings-env.js
-  # Env variable injection
-    sed -i \
-      -e "s#host:.*//#host: '${QUASSEL_CORE}', //#g" \
-      -e "s#port:.*,// quasselcore#port: ${QUASSEL_PORT}, // quasselcore#g" \
-      -e "s#forcedefault:.*//#forcedefault: true, //#g" \
-      /app/quassel-web/settings-env.js && \
-  [[ "${URL_BASE+x}" ]] && \
-    sed -i "s#prefixpath:.*//#prefixpath: \'${URL_BASE}\', //#g" \
-    /app/quassel-web/settings-env.js
-  if [ "${HTTPS}" == "true" ];then
-    sed -i \
-      -e "s#mode:.*// can be 'http'#mode: 'https', // can be 'http'#g" \
-      -e "s#port:.*// Port on which to listen#port: 64443, // Port on which to listen#g" \
-      /app/quassel-web/settings-env.js
-  else
-    sed -i \
-      -e "s#mode:.*// can be 'http'#mode: 'http', // can be 'http'#g" \
-      -e "s#port:.*// Port on which to listen#port: 64080, // Port on which to listen#g" \
-      /app/quassel-web/settings-env.js
+# env variable validation
+VARS=( \
+QUASSEL_CORE \
+QUASSEL_PORT \
+)
+for i in "${VARS[@]}"; do
+  if [ -z ${!i+x} ]; then
+    echo "[cont-init.d] ${i} is required to setup container with env variables falling back to config file"
+    echo "[cont-init.d] You will need to manually modify /config/settings-user.js"
+    [[ ! -f /config/settings-user.js ]] && \
+      cp -pr /app/quassel-web/settings.js /config/settings-user.js
+    chownfiles
+    exit 0
   fi
-# The user is not using env variables copy a default file if it does not exist
-else
-  [[ ! -f /config/settings-user.js ]] && \
-    echo "[cont-init.d] QUASSEL_CORE is not set, you will need to manually modify /config/settings-user.js"
-    cp -pr /app/quassel-web/settings.js /config/settings-user.js
-fi
-
+done
+echo "[cont-init.d] QUASSEL_CORE set, injecting env variables into settings.js"
+cp -pr /app/quassel-web/settings.js /app/quassel-web/settings-env.js
+# Env variable injection
+  sed -i \
+    -e "s#host:.*//#host: '${QUASSEL_CORE}', //#g" \
+    -e "s#port:.*,// quasselcore#port: ${QUASSEL_PORT}, // quasselcore#g" \
+    -e "s#forcedefault:.*//#forcedefault: true, //#g" \
+    -e "s#mode:.*// can be 'http'#mode: 'http', // can be 'http'#g" \
+    -e "s#port:.*// Port on which to listen#port: 64080, // Port on which to listen#g" \
+    /app/quassel-web/settings-env.js && \
+[[ "${URL_BASE+x}" ]] && \
+  sed -i "s#prefixpath:.*//#prefixpath: \'${URL_BASE}\', //#g" \
+  /app/quassel-web/settings-env.js
+# file permissions
 chownfiles

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -2,11 +2,14 @@
 
 # copy settings-user.js if doesn't exist
 [[ ! -f /config/settings-user.js ]] ; \
-	cp -pr /defaults/settings.js /config/settings-user.js
+	cp -pr /app/quassel-web/settings.js /config/settings-user.js
 
 # Fresh settings-env.js if using env variable
-rm /app/quassel-web/settings-env.js && \
-    cp -pr /defaults/settings.js /app/quassel-web/settings-env.js
+[[ -f /app/quassel-web/settings-env.js ]] ; \
+    rm /app/quassel-web/settings-env.js
+
+# Copy settings to be used for env variables
+cp -pr /app/quassel-web/settings.js /app/quassel-web/settings-env.js
 
 # add possibility to use env variables
 [[ "${QUASSEL_CORE}" ]] && \

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -38,12 +38,12 @@ if [ "${QUASSEL_CORE+x}" ]; then
     /app/quassel-web/settings-env.js
   if [ "${HTTPS}" == "true" ];then
     sed -i \
-      -e "s#mode:.*//#mode: 'https', //#g" \
+      -e "s#mode:.*// can be 'http'#mode: 'https', // can be 'http'#g" \
       -e "s#port:.*// Port on which to listen#port: 64443, // Port on which to listen#g" \
       /app/quassel-web/settings-env.js
   else
     sed -i \
-      -e "s#mode:.*//#mode: 'http', //#g" \
+      -e "s#mode:.*// can be 'http'#mode: 'http', // can be 'http'#g" \
       -e "s#port:.*// Port on which to listen#port: 64080, // Port on which to listen#g" \
       /app/quassel-web/settings-env.js
   fi

--- a/root/etc/services.d/quassel-web/run
+++ b/root/etc/services.d/quassel-web/run
@@ -1,14 +1,13 @@
 #!/usr/bin/with-contenv bash
 
 cd /app/quassel-web || true
+# determine config file to use
+if [ -f "/app/quassel-web/settings-env.js" ] && \
+   [ "${QUASSEL_CORE+x}" ]; then
+  CONFIG="/app/quassel-web/settings-env.js"
+else
+  CONFIG="/config/settings-user.js"
+fi
 
 exec \
-	s6-setuidgid abc node app.js -c /config/settings-user.js
-
-if [ "$ADVANCED" == "true" ]; then
-    exec \
-        s6-setuidgid abc node app.js -c /config/settings-user.js
-else
-    exec \
-        s6-setuidgid abc node app.js -c /app/quassel-web/settings-env.js
-fi
+  s6-setuidgid abc node app.js -c "${CONFIG}"

--- a/root/etc/services.d/quassel-web/run
+++ b/root/etc/services.d/quassel-web/run
@@ -4,3 +4,11 @@ cd /app/quassel-web || true
 
 exec \
 	s6-setuidgid abc node app.js -c /config/settings-user.js
+
+if [ "$ADVANCED" == "true" ]; then
+    exec \
+        s6-setuidgid abc node app.js -c /config/settings-user.js
+else
+    exec \
+        s6-setuidgid abc node app.js -c /app/quassel-web/settings-env.js
+fi


### PR DESCRIPTION
Now can configure through environmental variables or through direct editing of `/config/settings-user.js`

But are mutually exclusive.

Closes https://github.com/linuxserver/docker-quassel-web/issues/3