### PR TITLE
Add "NODE_ENV=production" to the example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ docker create \
   -e QUASSEL_CORE=192.168.1.10 \
   -e QUASSEL_PORT=4242 \
   -e URL_BASE=/quassel `#optional` \
+  -e NODE_ENV=production \
   -p 64080:64080 \
   -v <path to data>:/config \
   --restart unless-stopped \

--- a/root/etc/services.d/quassel-web/run
+++ b/root/etc/services.d/quassel-web/run
@@ -9,5 +9,5 @@ else
   CONFIG="/config/settings-user.js"
 fi
 
-exec \
+NODE_ENV=production exec \
   s6-setuidgid abc node app.js -c "${CONFIG}"


### PR DESCRIPTION
For a quick-deploy setup you probably want this as a default for security reasons.

If you care about the distinction between production/development NODE_ENV, you probably understand enough to know to change this in the snippet.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

